### PR TITLE
Support JavaCPP 1.5 and snapshot version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,11 +8,11 @@ sbtPlugin := true
 
 publishMavenStyle := true
 
-scalaVersion in Global := "2.12.8"
+scalaVersion in Global := "2.12.11"
 
-sbtVersion in Global := "1.2.7"
+sbtVersion in Global := "1.3.10"
 
-crossSbtVersions := Vector("0.13.17", "1.2.7")
+crossSbtVersions := Vector("0.13.18", "1.3.10")
 
 scalaCompilerBridgeSource := {
   val sv = appConfiguration.value.provider.id.version
@@ -23,7 +23,7 @@ publishArtifact in Test := false
 
 pomIncludeRepository := { _ => false }
 
-libraryDependencies += "org.bytedeco" % "javacpp" % "1.4.3"
+libraryDependencies += "org.bytedeco" % "javacpp" % "1.5.3"
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Xlint", "-Xlog-free-terms")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 classpathTypes += "maven-plugin"
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")

--- a/src/main/scala/org/bytedeco/sbt/javacpp/Plugin.scala
+++ b/src/main/scala/org/bytedeco/sbt/javacpp/Plugin.scala
@@ -22,7 +22,7 @@ object Plugin extends AutoPlugin {
   }
 
   object Versions {
-    val javaCppVersion = "1.4.3"
+    val javaCppVersion = "1.5.3"
   }
 
   object autoImport {
@@ -38,12 +38,12 @@ object Plugin extends AutoPlugin {
   private def javaCppPresetDependencies: Def.Setting[Seq[ModuleID]] = {
     import autoImport._
     libraryDependencies ++= {
-      val cppPresetVersion = buildPresetVersion(javaCppVersion.value)
+      val (cppPresetVersion, groupId) = buildPresetVersion(javaCppVersion.value)
       javaCppPresetLibs.value.flatMap {
         case (libName, libVersion) =>
-          val generic = "org.bytedeco.javacpp-presets" % libName % s"$libVersion-$cppPresetVersion" classifier ""
+          val generic = groupId % libName % s"$libVersion-$cppPresetVersion" classifier ""
           val platformSpecific = javaCppPlatform.value.map { platform =>
-            "org.bytedeco.javacpp-presets" % libName % s"$libVersion-$cppPresetVersion" classifier platform
+            groupId % libName % s"$libVersion-$cppPresetVersion" classifier platform
           }
           generic +: platformSpecific
       }
@@ -59,11 +59,11 @@ object Plugin extends AutoPlugin {
    *
    * @param version eg. "1.4.2"
    */
-  private def buildPresetVersion(version: String): String =
+  private def buildPresetVersion(version: String): (String, String) =
     version match {
-      case VersionSplit(a :: b :: _) if a < 2 & b < 4 => s"$a.$b"
-      case VersionSplit(_) => version
-      case _ => throw new IllegalArgumentException("Version format not recognized")
+      case VersionSplit(a :: b :: _) if a == 0 || (a == 1 && b <= 3) => (s"$a.$b", "org.bytedeco.javacpp-presets")
+      case VersionSplit(1 :: 4 :: _) => (version, "org.bytedeco.javacpp-presets")
+      case _ => (version, "org.bytedeco")
     }
 
   private object VersionSplit {

--- a/src/sbt-test/sbt-javacpp/simple/build.sbt
+++ b/src/sbt-test/sbt-javacpp/simple/build.sbt
@@ -1,5 +1,5 @@
 version := "0.1"
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.11"
 
 libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"

--- a/src/sbt-test/sbt-javacpp/simple/project/build.properties
+++ b/src/sbt-test/sbt-javacpp/simple/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.10


### PR DESCRIPTION
1. Supported JavaCPP 1.5. From 1.5 groupId changed from ```org.bytedeco.javacpp-presets``` to ```org.bytedeco```.
2. Supported JavaCPP 1.5.4-SNAPSHOT.
3. I updated many library versions.

See also https://github.com/bytedeco/javacpp-presets/issues/875 .

