### PR TITLE
Change from oraclejdk8 to openjdk8 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: scala
 jdk:
-  - oraclejdk8
+  - openjdk8
 script:
  - sbt scripted
 cache:


### PR DESCRIPTION
Travis changed the default OS from Ubuntu 14.04 to Ubuntu 16.04.
And oraclejdk8 is not supported on Ubuntu 16.04.
https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support
See also https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038