### PR TITLE
Support library name postfix

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,13 +15,16 @@ For the latest `version`, see the Maven badge at the top.
 Adding the above line will set up your project's classpath to include `maven-plugins` as well as a add a dependency on
 the core JavaCPP library.
 
+Due to the sbt limitation, add ```fork := true``` to ```build.sbt```.
+
 To add a dependency on a JavaCPP preset in your project, the following snippet will do that for you, taking care
-of adding the proper native preset for your target platform as well:
+of adding the proper native preset for your target platform as well. Remove ```-platform``` from the ```artifactId```:
 
 ```scala
 // in build.sbt
 
-javaCppPresetLibs ++= Seq("opencv" -> "3.4.0", "ffmpeg" -> "3.4.1")
+javaCppPresetLibs ++= Seq("opencv" -> "4.3.0", "opencv-gpu" -> "4.3.0", "mkl-redist" -> "2020.1")
+fork := true
 
 ```
 

--- a/src/sbt-test/sbt-javacpp/simple/build.sbt
+++ b/src/sbt-test/sbt-javacpp/simple/build.sbt
@@ -3,3 +3,7 @@ version := "0.1"
 scalaVersion := "2.12.11"
 
 libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
+
+javaCppPresetLibs ++= Seq("mkl" -> "2020.1", "mkl-redist" -> "2020.1")
+
+fork := true

--- a/src/sbt-test/sbt-javacpp/simple/src/test/java/javacpp/MklTest.java
+++ b/src/sbt-test/sbt-javacpp/simple/src/test/java/javacpp/MklTest.java
@@ -1,0 +1,11 @@
+package javacpp;
+
+import org.bytedeco.mkl.global.mkl_rt;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class MklTest {
+    @Test public void testGetMaxCpuFrequency() {
+        assertTrue(mkl_rt.MKL_Get_Max_Cpu_Frequency() > 0);
+    }
+}


### PR DESCRIPTION
Recently, some JavaCPP presets library names have postfix.
For example, ```opencv-gpu```, ```mkl-redist```, and ```tensorflow-python-gpu```.
```-gpu```, ```-redist```, and ```-python-gpu``` is postfix.
These postfixes go to ```classifier```.
I fixed this.

Sorry for sending this pull request after @lloydmeta released 1.15.
I just noticed now.