### PR TITLE
Update to JavaCPP 1.5.4 and use Loader.Detector.getPlatform to avoid "java.lang.UnsatisfiedLinkError: no jnijavacpp in java.library.path" message

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,7 +23,7 @@ of adding the proper native preset for your target platform as well. Remove ```-
 ```scala
 // in build.sbt
 
-javaCppPresetLibs ++= Seq("opencv" -> "4.3.0", "opencv-gpu" -> "4.3.0", "mkl-redist" -> "2020.1")
+javaCppPresetLibs ++= Seq("opencv" -> "4.4.0", "opencv-gpu" -> "4.4.0", "mkl-redist" -> "2020.3")
 fork := true
 
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ publishArtifact in Test := false
 
 pomIncludeRepository := { _ => false }
 
-libraryDependencies += "org.bytedeco" % "javacpp" % "1.5.3"
+libraryDependencies += "org.bytedeco" % "javacpp" % "1.5.4"
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Xlint", "-Xlog-free-terms")
 

--- a/src/main/scala/org/bytedeco/sbt/javacpp/Platform.scala
+++ b/src/main/scala/org/bytedeco/sbt/javacpp/Platform.scala
@@ -20,7 +20,7 @@ object Platform {
    */
   val current: Seq[String] = sys.props.get(platformOverridePropertyKey) match {
     case Some(platform) if platform.trim().nonEmpty => platform.split(' ')
-    case _ => Seq(Loader.getPlatform)
+    case _ => Seq(Loader.Detector.getPlatform)
   }
 
 }

--- a/src/sbt-test/sbt-javacpp/simple/build.sbt
+++ b/src/sbt-test/sbt-javacpp/simple/build.sbt
@@ -4,6 +4,6 @@ scalaVersion := "2.12.11"
 
 libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
 
-javaCppPresetLibs ++= Seq("mkl" -> "2020.1", "mkl-redist" -> "2020.1")
+javaCppPresetLibs ++= Seq("mkl" -> "2020.3", "mkl-redist" -> "2020.3")
 
 fork := true


### PR DESCRIPTION
Because of https://github.com/bytedeco/javacv/issues/1305 , you have to use ```javacpp-platform``` from JavaCPP 1.5.3.
You can avoid ```java.lang.UnsatisfiedLinkError: no jnijavacpp in java.library.path``` message by this.
